### PR TITLE
Disabling infinite terrain

### DIFF
--- a/ascz_map_fixes/ascz_aliabad_fix/config.cpp
+++ b/ascz_map_fixes/ascz_aliabad_fix/config.cpp
@@ -23,7 +23,20 @@ class CfgWorlds
 		description = "Aliabad";
 		pictureMap = "\ascz_aliabad_fix\Data\Aliabad_ca.paa";
 		pictureShot = "\ascz_aliabad_fix\Data\ui_aliabad_ca.paa";
-
+		
+		class OutsideTerrain
+		{
+			satellite = "MCN\MCN_Aliabad\data\ali_satout_co.paa";
+			enableTerrainSynth = 0;
+			class Layers
+			{
+				class Layer0
+				{
+					nopx = "MCN\MCN_Aliabad\data\ali_hlina_nopx.paa";
+					texture = "MCN\MCN_Aliabad\data\ali_hlina_co.paa";
+				};
+			};
+		};
         class Clutter
         {
             class sm_GrassCrooked: DefaultClutter

--- a/ascz_map_fixes/ascz_celle_fix/config.cpp
+++ b/ascz_map_fixes/ascz_celle_fix/config.cpp
@@ -30,7 +30,20 @@ class CfgWorlds
 		description = "Celle";
 		pictureMap = "\ascz_celle_fix\Data\Celle_ca.paa";
 		pictureShot = "\ascz_celle_fix\Data\ui_celle_ca.paa";
-
+		
+		class OutsideTerrain
+		{
+			satellite = "ca\CHERNARUS\data\s_satout_co.paa";
+			enableTerrainSynth = 0;
+			class Layers
+			{
+				class Layer0
+				{
+					nopx = "ca\CHERNARUS\data\cr_trava1_detail_nopx.paa";
+					texture = "ca\CHERNARUS\data\cr_trava1_detail_co.paa";
+				};
+			};
+		};
         class Clutter
         {
             class mbg_celle2_grass_green_long: DefaultClutter

--- a/ascz_map_fixes/ascz_clafghan_fix/config.cpp
+++ b/ascz_map_fixes/ascz_clafghan_fix/config.cpp
@@ -22,6 +22,20 @@ class CfgWorlds
 		description = "Clafghan";
 		pictureMap = "\ascz_clafghan_fix\Data\Clafghan_ca.paa";
 		pictureShot = "\ascz_clafghan_fix\Data\ui_clafghan_ca.paa";
+
+		class OutsideTerrain
+		{
+			satellite = "cla\clafghan\data\cla_cg_satout_co.paa";
+			enableTerrainSynth = 0;
+			class Layers
+			{
+				class Layer0
+				{
+					nopx = "cla\clafghan\data\cla_cg_terron_nopx.paa";
+					texture = "cla\clafghan\data\cla_cg_terron_co.paa";
+				};
+			};
+		};
 	};
 };
 class CfgMissions

--- a/ascz_map_fixes/ascz_torabora_fix/config.cpp
+++ b/ascz_map_fixes/ascz_torabora_fix/config.cpp
@@ -21,6 +21,20 @@ class CfgWorlds
 		description = "ToraBora";
 		pictureMap = "\ascz_torabora_fix\Data\ToraBora_Ca.paa";
 		pictureShot = "\ascz_torabora_fix\Data\ui_torabora_ca.paa";
+
+		class OutsideTerrain
+		{
+			satellite = "torabora\torabora\data\s_satout_co.paa";
+			enableTerrainSynth = 0;
+			class Layers
+			{
+				class Layer0
+				{
+					nopx = "torabora\torabora\data\tb_polopoust_nopx.paa";
+					texture = "torabora\torabora\data\tb_polopoust_co.paa";
+				};
+			};
+		};
 	};
 };
 class CfgMissions


### PR DESCRIPTION
Basically sets `enableTerrainSynth = 0` on terrains that have it defined. I don't use all or these terrains so did the one's I had locally.

Afghan Village doesn't have it defined (assume it defaults to 0)
Fallujah doesn't have it defined

Didn't check as I've never used:
Fata
Hazarkot
Nam
Reshmann

Not sure if any of those are land locked or not. Didn't bother adding stuff to credits or messing with versioning as not sure how you want to handle that stuff!

Side note: Since the patch appeared that fixed the terrain tiling issue, could probably redo the preview images!
